### PR TITLE
fix(yt-dlp): Add cookie-based authentication to bypass YouTube's bot …

### DIFF
--- a/app/api/download/route.ts
+++ b/app/api/download/route.ts
@@ -145,7 +145,18 @@ export async function POST(request: NextRequest) {
     console.log('Getting video info with command:', ytdlpCmdInfo);
 
     const videoInfo = await new Promise((resolve, reject) => {
-      const child = spawn(ytdlpCmdInfo, ['--dump-json', '--no-playlist', url], {
+      const browser = process.env.YT_DLP_BROWSER;
+      const args = ['--dump-json', '--no-playlist'];
+      if (browser) {
+        args.push('--cookies-from-browser', browser);
+        const userDataDir = process.env.YT_DLP_USER_DATA_DIR;
+        if (userDataDir) {
+          args.push('--user-data-dir', userDataDir);
+        }
+      }
+      args.push(url);
+
+      const child = spawn(ytdlpCmdInfo, args, {
         stdio: ['pipe', 'pipe', 'pipe']
       });
 
@@ -292,12 +303,22 @@ export async function POST(request: NextRequest) {
       '-o',
       tempFile, // Use full path for output
       '--no-playlist',
-      url,
     ];
+
+    const browser = process.env.YT_DLP_BROWSER;
+    if (browser) {
+      args.push('--cookies-from-browser', browser);
+      const userDataDir = process.env.YT_DLP_USER_DATA_DIR;
+      if (userDataDir) {
+        args.push('--user-data-dir', userDataDir);
+      }
+    }
 
     if (quality === 'audio') {
       args.push('--extract-audio', '--audio-format', 'mp3');
     }
+
+    args.push(url);
 
     const ytdlpCmd = getYtdlpCommand();
     console.log('Starting yt-dlp with command:', ytdlpCmd, args.join(' '));

--- a/app/api/video-info/route.ts
+++ b/app/api/video-info/route.ts
@@ -48,7 +48,21 @@ export async function POST(request: NextRequest) {
     }
 
     const ytdlpCmd = getYtdlpCommand();
-    const command = `${ytdlpCmd} --dump-json --no-playlist "${url}"`;
+
+    // Get browser from environment variables
+    const browser = process.env.YT_DLP_BROWSER;
+
+    let command = `${ytdlpCmd} --dump-json --no-playlist`;
+
+    if (browser) {
+      command += ` --cookies-from-browser ${browser}`;
+      const userDataDir = process.env.YT_DLP_USER_DATA_DIR;
+      if (userDataDir) {
+        command += ` --user-data-dir "${userDataDir}"`;
+      }
+    }
+
+    command += ` "${url}"`;
 
     const { stdout, stderr } = await execPromise(command, {
       timeout: 30000,


### PR DESCRIPTION
…detection

This commit introduces cookie-based authentication for `yt-dlp` to address errors caused by YouTube's bot detection. The changes allow users to specify a browser and a user data directory via environment variables, which are then used to add the `--cookies-from-browser` and `--user-data-dir` arguments to the `yt-dlp` command.

This approach resolves the "Sign in to confirm you’re not a bot" error by providing a secure and flexible way to authenticate `yt-dlp` requests without hardcoding any sensitive information. The changes have been applied to all instances where `yt-dlp` is used, ensuring consistent behavior across the application.